### PR TITLE
增加了IPAuth 和 heartbeat 模块

### DIFF
--- a/cmd/dbatman/main.go
+++ b/cmd/dbatman/main.go
@@ -2,17 +2,18 @@ package main
 
 import (
 	"flag"
-	"github.com/bytedance/dbatman/config"
-	"github.com/bytedance/dbatman/database/cluster"
-	"github.com/bytedance/dbatman/database/mysql"
-	"github.com/bytedance/dbatman/proxy"
-	"github.com/ngaut/log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
 	"syscall"
+
+	"github.com/bytedance/dbatman/config"
+	"github.com/bytedance/dbatman/database/cluster"
+	"github.com/bytedance/dbatman/database/mysql"
+	"github.com/bytedance/dbatman/proxy"
+	"github.com/ngaut/log"
 )
 
 var (
@@ -45,6 +46,12 @@ func main() {
 
 	mysql.SetLogger(log.Logger())
 
+	go func() {
+		err := cluster.DisasterControl()
+		if err != nil {
+			log.Debug(err)
+		}
+	}()
 	go func() {
 		//log.info("start checking config file")
 		cfg.CheckConfigUpdate(cluster.NotifyChan)

--- a/config/config.go
+++ b/config/config.go
@@ -160,10 +160,8 @@ func (cc *ClusterConfig) GetSlaveNodes() []*NodeConfig {
 
 func (c *Conf) parseConfigFile(proxyConfig *ProxyConfig) error {
 	data, err := ioutil.ReadFile(c.path)
-	log.Debug(c.path)
 	if err == nil {
 		err = yaml.Unmarshal([]byte(data), proxyConfig)
-		log.Debug(proxyConfig.GetGlobalConfig())
 		if err == nil {
 			if !validateConfig(proxyConfig) {
 				err = fmt.Errorf("config is invalidate")

--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,13 @@ package config
 
 import (
 	"fmt"
-	"github.com/ngaut/log"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/ngaut/log"
+	"gopkg.in/yaml.v2"
 )
 
 var conf Conf
@@ -36,6 +37,7 @@ type GlobalConfig struct {
 	ServerTimeout     int      `yaml:"server_timeout"`
 	WriteTimeInterval int      `yaml:"write_time_interval"`
 	ConfAutoload      int      `yaml:"conf_autoload"`
+	AuthIPActive      bool     `yaml:"authip_active"`
 	AuthIPs           []string `yaml:"auth_ips,omitempty"`
 }
 
@@ -134,6 +136,16 @@ func (p *ProxyConfig) GetUserByName(username string) (*UserConfig, error) {
 	return user, nil
 }
 
+func (p *ProxyConfig) GetGlobalConfig() (*GlobalConfig, error) {
+
+	globalconfig := p.Global
+	if globalconfig == nil {
+		err := fmt.Errorf("Global config do not exist")
+		return nil, err
+	}
+	return globalconfig, nil
+}
+
 func (p *ProxyConfig) ServerTimeout() int {
 	return p.Global.ServerTimeout
 }
@@ -148,8 +160,10 @@ func (cc *ClusterConfig) GetSlaveNodes() []*NodeConfig {
 
 func (c *Conf) parseConfigFile(proxyConfig *ProxyConfig) error {
 	data, err := ioutil.ReadFile(c.path)
+	log.Debug(c.path)
 	if err == nil {
 		err = yaml.Unmarshal([]byte(data), proxyConfig)
+		log.Debug(proxyConfig.GetGlobalConfig())
 		if err == nil {
 			if !validateConfig(proxyConfig) {
 				err = fmt.Errorf("config is invalidate")
@@ -278,6 +292,7 @@ func getDefaultProxyConfig() *ProxyConfig {
 			ServerTimeout:     1800,
 			WriteTimeInterval: 10,
 			ConfAutoload:      1,
+			AuthIPActive:      true,
 			AuthIPs:           []string{"127.0.0.1"},
 		},
 	}

--- a/database/cluster/driver.go
+++ b/database/cluster/driver.go
@@ -108,8 +108,14 @@ func DisasterControl() error {
 				return err
 			}
 			if crashDb.crashNum != 0 {
-				//TODO
-				log.Debug("db disconnect :", crashDb)
+				//TODO add the Manager module to contorle the diseaster
+				if crashDb.masterNode != nil {
+					log.Debug("db disconnect :", crashDb.masterNode.Dsn())
+				}
+				if len(crashDb.slaveNode) != 0 {
+					log.Debug("db disconnect ", crashDb.slaveNode)
+				}
+
 			}
 			//all dbs of the current cluster connecting pass
 		}
@@ -128,7 +134,7 @@ func (c *Cluster) HeartBeat() (*CrashDb, error) {
 	masterDb := c.masterNode
 	slaveDbs := c.slaveNodes
 
-	err := masterDb.Ping()
+	err := masterDb.HeartBeatPing()
 	if err != nil {
 		ret.crashNum++
 		ret.masterNode = masterDb

--- a/database/cluster/driver.go
+++ b/database/cluster/driver.go
@@ -134,14 +134,14 @@ func (c *Cluster) HeartBeat() (*CrashDb, error) {
 	masterDb := c.masterNode
 	slaveDbs := c.slaveNodes
 
-	err := masterDb.HeartBeatPing()
+	err := masterDb.Ping() //HeartBeatPing or Ping use single conn or user conn from conn pools
 	if err != nil {
 		ret.crashNum++
 		ret.masterNode = masterDb
 	}
 
 	for _, slavedb := range slaveDbs {
-		err := slavedb.HeartBeatPing()
+		err := slavedb.Ping()
 		if err != nil {
 			ret.slaveNode = append(ret.slaveNode, slavedb)
 		}

--- a/database/cluster/driver.go
+++ b/database/cluster/driver.go
@@ -135,7 +135,7 @@ func (c *Cluster) HeartBeat() (*CrashDb, error) {
 	}
 
 	for _, slavedb := range slaveDbs {
-		err := slavedb.Ping()
+		err := slavedb.HeartBeatPing()
 		if err != nil {
 			ret.slaveNode = append(ret.slaveNode, slavedb)
 		}

--- a/database/cluster/driver.go
+++ b/database/cluster/driver.go
@@ -92,17 +92,17 @@ Problem the ping use the conn pool to ping the db
 func DisasterControl() error {
 	index := 1
 	for {
-		if index > 10 {
+		if index > 1000 {
 			break
 		}
 		index++
 		time.Sleep(time.Second)
-		log.Info("")
 		if len(clusterConns) == 0 {
 			err := fmt.Errorf("There is no cluster init")
 			return err
 		}
-		for _, c := range clusterConns {
+		for name, c := range clusterConns {
+			log.Info("HeartBeart test the db healthy of clusters:", name)
 			crashDb, err := c.HeartBeat()
 			if err != nil {
 				return err

--- a/database/mysql/pool.go
+++ b/database/mysql/pool.go
@@ -541,6 +541,7 @@ func (db *DB) HeartBeatPing() error {
 	if broken, err := db.hbConn.isIdleConnectionBroken(); broken {
 		db.mu.Unlock()
 		db.hbConn.Close()
+		db.hbConn = nil
 		db.mu.Lock()
 		log.Warnf("close db(%s) broken conneciton", db.dsn)
 		return err

--- a/database/mysql/pool.go
+++ b/database/mysql/pool.go
@@ -229,6 +229,8 @@ type DB struct {
 	// connections in Stmt.css.
 	numClosed uint64
 
+	aliveStatus bool // indicate the result heartbeat detected the healthy of the db
+
 	mu     sync.Mutex  // protects following fields
 	hbConn *driverConn //heart beat Conn
 
@@ -627,6 +629,17 @@ func (db *DB) SetMaxIdleConns(n int) {
 	}
 }
 
+//
+func (db *DB) SetDbAliveStatus(status bool) {
+	db.mu.Lock()
+	db.aliveStatus = status
+	db.mu.Unlock()
+}
+
+func (db *DB) GetDbAliveStatus() bool {
+	return db.aliveStatus
+}
+
 // SetMaxOpenConns sets the maximum number of open connections to the database.
 //
 // If MaxIdleConns is greater than 0 and the new MaxOpenConns is less than
@@ -654,6 +667,7 @@ type DBStats struct {
 	// FreeConnections is the number of pool connections to the database
 	OpenConnections int
 	FreeConnections int
+	AliveStatus     bool
 }
 
 // Stats returns database statistics.
@@ -662,6 +676,7 @@ func (db *DB) Stats() DBStats {
 	stats := DBStats{
 		OpenConnections: db.numOpen,
 		FreeConnections: len(db.freeConn),
+		AliveStatus:     db.aliveStatus,
 	}
 	db.mu.Unlock()
 	return stats

--- a/database/mysql/pool.go
+++ b/database/mysql/pool.go
@@ -530,6 +530,7 @@ func (db *DB) HeartBeatPing() error {
 	if db.hbConn == nil {
 		dc, err := db.signleconn()
 		if err != nil {
+			log.Info("could not connect to db:", db.dsn)
 			return err
 		}
 		db.mu.Lock()

--- a/proxy/auth.go
+++ b/proxy/auth.go
@@ -68,7 +68,6 @@ func (session *Session) CheckAuth(username string, passwd []byte, db string) err
 	//check the global authip
 	gc, err := session.config.GetGlobalConfig()
 	cliAddr := session.cliAddr
-	log.Debug(len(gc.AuthIPs))
 	if len(gc.AuthIPs) > 0 {
 		//TODO white and black ip logic
 		globalAuthIp := &gc.AuthIPs
@@ -81,9 +80,8 @@ func (session *Session) CheckAuth(username string, passwd []byte, db string) err
 		}
 
 		if authIpFlag != true {
-			log.Debug("This user's Ip is not in the list of User's auth_Ip")
+			// log.Info("This user's Ip is not in the list of User's auth_Ip")
 			return NewDefaultError(ER_NO, "IP Is not in the auth_ip list of the global config")
-			log.Debug("checking the global auth")
 		}
 
 	}

--- a/proxy/auth.go
+++ b/proxy/auth.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/sha1"
+	"io"
+
 	. "github.com/bytedance/dbatman/database/mysql"
 	"github.com/ngaut/log"
-	"io"
 )
 
 func RandomBuf(size int) ([]byte, error) {
@@ -64,7 +65,29 @@ func CalcPassword(scramble, password []byte) []byte {
 func (session *Session) CheckAuth(username string, passwd []byte, db string) error {
 
 	var err error
+	//check the global authip
+	gc, err := session.config.GetGlobalConfig()
+	cliAddr := session.cliAddr
+	log.Debug(len(gc.AuthIPs))
+	if len(gc.AuthIPs) > 0 {
+		//TODO white and black ip logic
+		globalAuthIp := &gc.AuthIPs
+		authIpFlag := false
+		for _, ip := range *globalAuthIp {
+			if ip == cliAddr {
+				authIpFlag = true
+				break
+			}
+		}
 
+		if authIpFlag != true {
+			log.Debug("This user's Ip is not in the list of User's auth_Ip")
+			return NewDefaultError(ER_NO, "IP Is not in the auth_ip list of the global config")
+			log.Debug("checking the global auth")
+		}
+
+	}
+	//global auth pass
 	// There is no user named with parameter username
 	if session.user, err = session.config.GetUserByName(username); err != nil {
 		if session.user == nil {
@@ -77,7 +100,25 @@ func (session *Session) CheckAuth(username string, passwd []byte, db string) err
 		log.Debugf("request db: %s, user's db: %s", db, session.user.DBName)
 		return NewDefaultError(ER_BAD_DB_ERROR, db)
 	}
+	//TODO add the IP auth module to check the global auth_ip
+	//check user config auth_IP with current Session Ip
+	if len(session.user.AuthIPs) > 0 {
+		userIPs := &session.user.AuthIPs
+		authIpFlag := false
+		log.Debug("client IP : ", session.cliAddr)
+		log.Debug("User's Auth IP is: ", userIPs)
+		for _, ip := range *userIPs {
+			if cliAddr == ip {
+				authIpFlag = true
+				break
+			}
+		}
+		if authIpFlag != true {
+			log.Debug("This user's Ip is not in the list of User's auth_Ip")
 
+			return NewDefaultError(ER_NO, "IP Is not in the auth_ip list of the user")
+		}
+	}
 	if !bytes.Equal(passwd, CalcPassword(session.salt, []byte(session.user.Password))) {
 		return NewDefaultError(ER_ACCESS_DENIED_ERROR, session.user.Username, session.fc.RemoteAddr().String(), "Yes")
 	}

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -42,7 +42,6 @@ func NewServer(cfg *config.Conf) (*Server, error) {
 
 func (s *Server) Serve() error {
 	s.running = true
-
 	for s.running {
 		conn, err := s.listener.Accept()
 		if err != nil {

--- a/proxy/session.go
+++ b/proxy/session.go
@@ -15,6 +15,9 @@ package proxy
 
 import (
 	"errors"
+	"net"
+	"strings"
+
 	"github.com/bytedance/dbatman/cmd/version"
 	"github.com/bytedance/dbatman/config"
 	"github.com/bytedance/dbatman/database/cluster"
@@ -22,7 +25,6 @@ import (
 	"github.com/bytedance/dbatman/database/sql/driver"
 	"github.com/bytedance/dbatman/hack"
 	"github.com/ngaut/log"
-	"net"
 )
 
 type Session struct {
@@ -35,6 +37,8 @@ type Session struct {
 	cluster *cluster.Cluster
 	bc      *SqlConn
 	fc      *MySQLServerConn
+
+	cliAddr string //client ip for auth
 
 	closed bool
 
@@ -49,6 +53,8 @@ func (s *Server) newSession(conn net.Conn) *Session {
 	session.server = s
 	session.config = s.cfg.GetConfig()
 	session.salt, _ = RandomBuf(20)
+
+	session.cliAddr = strings.Split(conn.RemoteAddr().String(), ":")[0]
 
 	session.fc = NewMySQLServerConn(session, conn)
 	//session.lastcmd = ComQuit


### PR DESCRIPTION
1-现在可以根据配置文件的IP信息对连接进行拦截
2-也可以通过heartbeat检测出来下线的机器
*本来想把从库下线部分完成，不过这个得以来旁路管理模块 先把这两个MODULE的部分提一下
*SQL指纹牵扯到的地方比较多，比如后面的流量限制，有空还得和张博讨论下
*心跳检测有两个方案一个是用原来的连接池 还有一个是单独起一个连接 不过还在考虑单独连接的回收会不会有什么问题 所以都留了一个接口